### PR TITLE
added showALL

### DIFF
--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -18,8 +18,13 @@ export const ApplicationViews = () => {
         }
     }])
 
-    const fetchRocksFromAPI = async () => {
-        const response = await fetch("http://localhost:8000/rocks",
+    const fetchRocksFromAPI = async (showAll) => {
+        let url = "http://localhost:8000/rocks"
+
+        if (showAll !== true) {
+            url = "http://localhost:8000/rocks?owner=current"
+        }
+        const response = await fetch(url,
             {
                 headers: {
                     Authorization: `Token ${JSON.parse(localStorage.getItem("rock_token")).token}`
@@ -35,9 +40,9 @@ export const ApplicationViews = () => {
             <Route path="/register" element={<Register />} />
             <Route element={<Authorized />}>
                 <Route path="/" element={<Home />} />
-                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                <Route path="/allrocks" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} showAll={true} />} />
                 <Route path="/create" element={<RockForm fetchRocks={fetchRocksFromAPI} />} />
-                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} />} />
+                <Route path="/mine" element={<RockList rocks={rocksState} fetchRocks={fetchRocksFromAPI} showAll={false} />} />
             </Route>
         </Routes>
     </BrowserRouter>

--- a/src/components/RockForm.jsx
+++ b/src/components/RockForm.jsx
@@ -5,7 +5,7 @@ export const RockForm = ({ fetchRocks }) => {
     const initialRockState = {
         name: "",
         weight: 0,
-        typeId: 0
+        type_id: 0
     }
 
     const [types, changeTypes] = useState([{ id: 1, label: "Igneous" }, { id: 2, label: "Volcanic" }])
@@ -47,7 +47,7 @@ export const RockForm = ({ fetchRocks }) => {
     return (
         <main className="container--login">
             <section>
-                <form className="form--login" onSubmit={() => { }}>
+                <form className="form--login" onSubmit={collectRock}>
                     <h1 className="text-3xl">Collect a Rock</h1>
                     <fieldset className="mt-4">
                         <label htmlFor="rock">Name:</label>

--- a/src/components/RockList.jsx
+++ b/src/components/RockList.jsx
@@ -1,18 +1,36 @@
 import { useEffect } from "react"
 
-export const RockList = ({ rocks, fetchRocks }) => {
+export const RockList = ({ rocks, fetchRocks, showAll }) => {
     useEffect(() => {
-    }, [])
+        fetchRocks(showAll)
+    }, [showAll])
 
     const displayRocks = () => {
         if (rocks && rocks.length) {
-            return rocks.map(rock => <div key={`key-${rock.id}`} className="border p-5 border-solid hover:bg-fuchsia-500 hover:text-violet-50 rounded-md border-violet-900 mt-5 bg-slate-50">
-                {rock.name} ({rock.type.label})
-            </div>)
+            return rocks.map((rock) => (
+                <div key={`key-${rock.id}`} className="border p-5 border-solid hover:bg-fuchsia-500 hover:text-violet-50 rounded-md border-violet-900 mt-5 bg-slate-50">
+                    <div>{rock.name} ({rock.type.label})</div>
+                    {rock.user ? (
+                        <div>In the collection of {rock.user.first_name} {rock.user.last_name} 
+                            <button 
+                                onClick={async ()=> {
+                                    const response = await fetch(`http://localhost:8000/rocks/${rock.id}`, {
+                                        method: "Delete",
+                                        headers: {
+                                            Authorization: `Token ${JSON.parse(localStorage.getItem("rock_token")).token}`
+                                        }
+                                    })
+                                }}
+                                className="border border-solid bg-red-700 text-white p-1">Delete</button></div>
+                    ) : (
+                        <div>User information not available <button>Delete</button></div>
+                    )}
+                </div>
+            ));
         }
-
-        return <h3>Loading Rocks...</h3>
-    }
+    
+        return <h3>Loading Rocks...</h3>;
+    };
 
     return (
         <>


### PR DESCRIPTION
Added a key prop to the Routes which will specify the correct fetch for either a view of "mine" or "allrocks" by checking for showAll boolean is true or false in the FetchRockFromAPI. 

GIVEN when a user wishes to see their rocks only when they visit the /mine section they will only be shown the rocks matching current user_id
WHEN a user wishes to see all rocks when they visit the "/allrocks" page they will see all the user rock and both of these views have been loaded with a delete button to delete the rocks where the user_id matches.  